### PR TITLE
Boost v1.74+ support + Docker version

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,11 +289,13 @@ _(`Vue.js` is a good replace for jQ at small project , i only use it's data and 
 ### Dependencies
 
 **CMake** >= 3.16  
-**Boost** >= 1.70  recommend  1.73  
+**Boost** >= 1.74
+> For older versions Boost v1.70+ (v1.73 is recommended as last working version)
+> Checkout at tag "v1.0" or commit "e6c491ce56f6de21423c5d780d1c8865714fabe3"
 **OpenSSL** >= 1.1.0 recommend 1.1.1h  
 **MSVC** or **GCC** , required C++17 support  
 
-#### windows
+#### Build on Windows
 
 install VS2019
 
@@ -306,18 +308,6 @@ OpenSSL Prebuild :
 - https://wiki.openssl.org/index.php/Binaries
 - https://kb.firedaemon.com/support/solutions/articles/4000121705
 
-#### ArchLinux
-
-```
-pacman -S base-devel --needed
-pacman -S boost
-pacman -S openssl
-pacman -S cmake
-```
-
-### Build
-
-#### windows
 
 ```
 cmake -DBOOST_INCLUDEDIR=<path_to>/boost_1_73_0 -DOPENSSL_ROOT_DIR=<path_to>\openssl-1.1.1h\x64
@@ -325,8 +315,33 @@ cmake -DBOOST_INCLUDEDIR=<path_to>/boost_1_73_0 -DOPENSSL_ROOT_DIR=<path_to>\ope
 
 then build it
 
+#### Build on ArchLinux
 
-#### ArchLinux
+```
+pacman -S base-devel --needed
+pacman -S openssl
+pacman -S cmake
+```
+
+```bash
+# IF YOU WANT TO BUILD WITH LATEST BOOST (v1.74+)
+pacman -S boost
+```
+
+> **If you are building older version, run:**
+>
+> ```bash
+> # DOWNLOAD & BUILD BOOST v1.73 FROM SOURCE
+> wget -nc https://boostorg.jfrog.io/artifactory/main/release/1.73.0/source/boost_1_73_0.tar.bz2
+> tar --skip-old-files -jxf boost_1_73_0.tar.bz2
+> cd boost_1_73_0
+> ./bootstrap.sh
+> ./b2 link=static
+> PATH=$(pwd):$(pwd)/stage/lib:$PATH
+> cd ..
+> ```
+
+
 
 ```
 cd ./Socks5BalancerAsio
@@ -335,6 +350,44 @@ make
 ```
 
 then all ok
+
+#### Build on Debian
+
+```bash
+# FOR LATEST BOOST (v1.74+):
+apt update && apt upgrade
+apt install -y libboost-all-dev git cmake libssl-dev g++
+git clone https://github.com/fossforreal/Socks5BalancerAsio
+cd Socks5BalancerAsio
+cmake .
+make -j$(nproc)
+
+```
+
+or
+
+```bash
+# FOR BOOST v1.71-1.73:
+apt update && apt upgrade
+apt install -y git cmake libssl-dev g++ wget bzip2
+
+# DOWNLOAD & BUILD BOOST v1.73 FROM SOURCE
+wget -nc https://boostorg.jfrog.io/artifactory/main/release/1.73.0/source/boost_1_73_0.tar.bz2
+tar --skip-old-files -jxf boost_1_73_0.tar.bz2
+cd boost_1_73_0
+./bootstrap.sh
+./b2 link=static
+PATH=$(pwd):$(pwd)/stage/lib:$PATH
+cd ..
+
+# CHECK THIS REPO AT TAG v1.0
+git clone https://github.com/fossforreal/Socks5BalancerAsio
+cd Socks5BalancerAsio
+git checkout e6c491ce56f6de21423c5d780d1c8865714fabe3
+cmake .
+make -j$(nproc)
+```
+
 
 ### Dev
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Socks5BalancerAsio
-A Simple TCP Socket Balancer for balance Multi Socks5 Proxy Backend Powered by Boost.Asio
+A Simple TCP Socket Balancer for balance Multi Socks5 Proxy Backend Servers Powered by Boost.Asio
+
+---
+
+Docker version available with instructions here: [fossforreal/Socks5BalancerAsio-Docker](https://github.com/fossforreal/Socks5BalancerAsio-Docker)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ _(`Vue.js` is a good replace for jQ at small project , i only use it's data and 
 **Boost** >= 1.74
 > For older versions Boost v1.70+ (v1.73 is recommended as last working version)
 > Checkout at tag "v1.0" or commit "e6c491ce56f6de21423c5d780d1c8865714fabe3"
+
 **OpenSSL** >= 1.1.0 recommend 1.1.1h  
 **MSVC** or **GCC** , required C++17 support  
 

--- a/example-config/FullConfig.json
+++ b/example-config/FullConfig.json
@@ -2,6 +2,7 @@
   "listenHost": "127.0.0.1",
   "listenPort": 5000,
   "retryTimes": 3,
+  "connectTimeout": 2000,
   "testRemoteHost": "www.google.com",
   "testRemotePort": 443,
   "tcpCheckPeriod": 5000,

--- a/src/AsyncDelay.cpp
+++ b/src/AsyncDelay.cpp
@@ -21,7 +21,7 @@
 #include <iostream>
 #include <boost/asio/steady_timer.hpp>
 
-void asyncDelay(std::chrono::milliseconds delayTime, boost::asio::executor executor, std::function<void()> callback) {
+void asyncDelay(std::chrono::milliseconds delayTime, boost::asio::any_io_executor executor, std::function<void()> callback) {
 
     auto timer = std::make_shared<boost::asio::steady_timer>(executor, delayTime);
 

--- a/src/AsyncDelay.h
+++ b/src/AsyncDelay.h
@@ -20,13 +20,13 @@
 #define SOCKS5BALANCERASIO_ASYNCDELAY_H
 
 
-#include <boost/asio/executor.hpp>
+#include <boost/asio/any_io_executor.hpp>
 #include <memory>
 #include <chrono>
 #include <functional>
 
 
-void asyncDelay(std::chrono::milliseconds delayTime, boost::asio::executor executor, std::function<void()> callback);
+void asyncDelay(std::chrono::milliseconds delayTime, boost::asio::any_io_executor executor, std::function<void()> callback);
 
 
 #endif //SOCKS5BALANCERASIO_ASYNCDELAY_H

--- a/src/ConnectTestHttps.cpp
+++ b/src/ConnectTestHttps.cpp
@@ -22,7 +22,7 @@
 
 #include <boost/beast/version.hpp>
 
-ConnectTestHttpsSession::ConnectTestHttpsSession(boost::asio::executor executor,
+ConnectTestHttpsSession::ConnectTestHttpsSession(boost::asio::any_io_executor executor,
                                                  const std::shared_ptr<boost::asio::ssl::context> &ssl_context,
                                                  const std::string &targetHost, uint16_t targetPort,
                                                  const std::string &targetPath, int httpVersion,
@@ -138,7 +138,7 @@ void ConnectTestHttpsSession::do_resolve() {
 }
 
 void ConnectTestHttpsSession::do_tcp_connect(
-        const boost::asio::ip::basic_resolver<boost::asio::ip::tcp, boost::asio::executor>::results_type &results) {
+        const boost::asio::ip::basic_resolver<boost::asio::ip::tcp, boost::asio::any_io_executor>::results_type &results) {
 
 
     // Set a timeout on the operation
@@ -444,7 +444,7 @@ void ConnectTestHttpsSession::do_shutdown(bool isOn) {
                     }));
 }
 
-ConnectTestHttps::ConnectTestHttps(boost::asio::executor ex) :
+ConnectTestHttps::ConnectTestHttps(boost::asio::any_io_executor ex) :
         executor(ex),
         ssl_context(std::make_shared<boost::asio::ssl::context>(boost::asio::ssl::context::sslv23)) {
 

--- a/src/ConnectTestHttps.h
+++ b/src/ConnectTestHttps.h
@@ -23,7 +23,7 @@
 #pragma once
 #endif
 
-#include <boost/asio/executor.hpp>
+#include <boost/asio/any_io_executor.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/ssl.hpp>
 #include <boost/asio/steady_timer.hpp>
@@ -50,7 +50,7 @@
 #endif // _WIN32
 
 class ConnectTestHttpsSession : public std::enable_shared_from_this<ConnectTestHttpsSession> {
-    boost::asio::executor executor;
+    boost::asio::any_io_executor executor;
 
     boost::asio::ip::tcp::resolver resolver_;
     boost::beast::ssl_stream<boost::beast::tcp_stream> stream_;
@@ -76,7 +76,7 @@ class ConnectTestHttpsSession : public std::enable_shared_from_this<ConnectTestH
 
 public:
     ConnectTestHttpsSession(
-            boost::asio::executor executor,
+            boost::asio::any_io_executor executor,
             const std::shared_ptr<boost::asio::ssl::context> &ssl_context,
             const std::string &targetHost,
             uint16_t targetPort,
@@ -149,14 +149,14 @@ private:
 };
 
 class ConnectTestHttps : public std::enable_shared_from_this<ConnectTestHttps> {
-    boost::asio::executor executor;
+    boost::asio::any_io_executor executor;
     std::shared_ptr<boost::asio::ssl::context> ssl_context;
     bool need_verify_ssl = true;
     std::list<std::shared_ptr<ConnectTestHttpsSession>> sessions;
 
     std::shared_ptr<boost::asio::steady_timer> cleanTimer;
 public:
-    ConnectTestHttps(boost::asio::executor ex);
+    ConnectTestHttps(boost::asio::any_io_executor ex);
 
     std::shared_ptr<ConnectTestHttpsSession> createTest(
             const std::string &socks5Host,

--- a/src/EmbedWebServer.h
+++ b/src/EmbedWebServer.h
@@ -25,7 +25,7 @@
 
 // https://www.boost.org/doc/libs/develop/libs/beast/example/http/server/async/http_server_async.cpp
 
-#include <boost/asio/executor.hpp>
+#include <boost/asio/any_io_executor.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/beast/core.hpp>
 #include <boost/beast/http.hpp>

--- a/src/StateMonitorServer.cpp
+++ b/src/StateMonitorServer.cpp
@@ -793,7 +793,7 @@ void HttpConnectSession::create_response() {
 void HttpConnectSession::write_response() {
     auto self = shared_from_this();
 
-    response_.set(boost::beast::http::field::content_length, response_.body().size());
+    response_.set(boost::beast::http::field::content_length, std::to_string(response_.body().size()));
 
     boost::beast::http::async_write(
             socket_,

--- a/src/StateMonitorServer.h
+++ b/src/StateMonitorServer.h
@@ -23,7 +23,7 @@
 #pragma once
 #endif
 
-#include <boost/asio/executor.hpp>
+#include <boost/asio/any_io_executor.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/beast/core.hpp>
 #include <boost/beast/http.hpp>
@@ -105,7 +105,7 @@ protected:
 };
 
 class StateMonitorServer : public std::enable_shared_from_this<StateMonitorServer> {
-    boost::asio::executor ex;
+    boost::asio::any_io_executor ex;
     std::shared_ptr<ConfigLoader> configLoader;
     std::shared_ptr<UpstreamPool> upstreamPool;
     std::shared_ptr<TcpRelayServer> tcpRelayServer;
@@ -113,7 +113,7 @@ class StateMonitorServer : public std::enable_shared_from_this<StateMonitorServe
     UpstreamTimePoint startTime;
 public:
     StateMonitorServer(
-            boost::asio::executor ex,
+            boost::asio::any_io_executor ex,
             std::shared_ptr<ConfigLoader> configLoader,
             std::shared_ptr<UpstreamPool> upstreamPool,
             std::shared_ptr<TcpRelayServer> tcpRelayServer

--- a/src/TcpRelayServer.h
+++ b/src/TcpRelayServer.h
@@ -23,7 +23,7 @@
 #pragma once
 #endif
 
-#include <boost/asio/executor.hpp>
+#include <boost/asio/any_io_executor.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <memory>
 #include <string>
@@ -40,7 +40,7 @@
 // code template from https://github.com/ArashPartow/proxy/blob/master/tcpproxy_server.cpp
 class TcpRelaySession : public std::enable_shared_from_this<TcpRelaySession> {
 
-    boost::asio::executor ex;
+    boost::asio::any_io_executor ex;
 
     boost::asio::ip::tcp::socket downstream_socket_;
     boost::asio::ip::tcp::socket upstream_socket_;
@@ -76,7 +76,7 @@ class TcpRelaySession : public std::enable_shared_from_this<TcpRelaySession> {
     bool isDeCont = false;
 public:
     TcpRelaySession(
-            boost::asio::executor ex,
+            boost::asio::any_io_executor ex,
             std::shared_ptr<UpstreamPool> upstreamPool,
             std::weak_ptr<TcpRelayStatisticsInfo> statisticsInfo,
             size_t retryLimit,
@@ -172,7 +172,7 @@ public:
 
 class TcpRelayServer : public std::enable_shared_from_this<TcpRelayServer> {
 
-    boost::asio::executor ex;
+    boost::asio::any_io_executor ex;
     std::shared_ptr<ConfigLoader> configLoader;
     std::shared_ptr<UpstreamPool> upstreamPool;
     std::list<boost::asio::ip::tcp::acceptor> socket_acceptors;
@@ -184,7 +184,7 @@ class TcpRelayServer : public std::enable_shared_from_this<TcpRelayServer> {
     std::shared_ptr<boost::asio::steady_timer> speedCalcTimer;
 public:
     TcpRelayServer(
-            boost::asio::executor ex,
+            boost::asio::any_io_executor ex,
             std::shared_ptr<ConfigLoader> configLoader,
             std::shared_ptr<UpstreamPool> upstreamPool
     ) : ex(ex),

--- a/src/TcpTest.cpp
+++ b/src/TcpTest.cpp
@@ -46,7 +46,7 @@ void TcpTestSession::do_resolve() {
 }
 
 void TcpTestSession::do_tcp_connect(
-        const boost::asio::ip::basic_resolver<boost::asio::ip::tcp, boost::asio::executor>::results_type &results) {
+        const boost::asio::ip::basic_resolver<boost::asio::ip::tcp, boost::asio::any_io_executor>::results_type &results) {
 
     // Set a timeout on the operation
     boost::beast::get_lowest_layer(stream_).expires_after(std::chrono::seconds(30));

--- a/src/TcpTest.h
+++ b/src/TcpTest.h
@@ -23,7 +23,7 @@
 #pragma once
 #endif
 
-#include <boost/asio/executor.hpp>
+#include <boost/asio/any_io_executor.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/beast/core.hpp>
@@ -41,7 +41,7 @@
 
 
 class TcpTestSession : public std::enable_shared_from_this<TcpTestSession> {
-    boost::asio::executor executor;
+    boost::asio::any_io_executor executor;
 
     boost::asio::ip::tcp::resolver resolver_;
     boost::beast::tcp_stream stream_;
@@ -54,7 +54,7 @@ class TcpTestSession : public std::enable_shared_from_this<TcpTestSession> {
     bool _isComplete = false;
 
 public:
-    TcpTestSession(boost::asio::executor executor,
+    TcpTestSession(boost::asio::any_io_executor executor,
                    const std::string &socks5Host,
                    const std::string &socks5Port,
                    std::chrono::milliseconds delayTime = std::chrono::milliseconds{0}
@@ -108,12 +108,12 @@ private:
 };
 
 class TcpTest : public std::enable_shared_from_this<TcpTest> {
-    boost::asio::executor executor;
+    boost::asio::any_io_executor executor;
     std::list<std::shared_ptr<TcpTestSession>> sessions;
 
     std::shared_ptr<boost::asio::steady_timer> cleanTimer;
 public:
-    TcpTest(boost::asio::executor ex) :
+    TcpTest(boost::asio::any_io_executor ex) :
             executor(ex) {
     }
 

--- a/src/UpstreamPool.cpp
+++ b/src/UpstreamPool.cpp
@@ -62,7 +62,7 @@ void UpstreamServer::updateOnlineTime() {
     lastOnlineTime = UpstreamTimePointNow();
 }
 
-UpstreamPool::UpstreamPool(boost::asio::executor ex, std::shared_ptr<TcpTest> tcpTest,
+UpstreamPool::UpstreamPool(boost::asio::any_io_executor ex, std::shared_ptr<TcpTest> tcpTest,
                            std::shared_ptr<ConnectTestHttps> connectTestHttps)
         : ex(ex),
           tcpTest(std::move(tcpTest)),

--- a/src/UpstreamPool.h
+++ b/src/UpstreamPool.h
@@ -23,7 +23,7 @@
 #pragma once
 #endif
 
-#include <boost/asio/executor.hpp>
+#include <boost/asio/any_io_executor.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <string>
 #include <deque>
@@ -82,7 +82,7 @@ struct UpstreamServer : public std::enable_shared_from_this<UpstreamServer> {
 using UpstreamServerRef = std::shared_ptr<UpstreamServer>;
 
 class UpstreamPool : public std::enable_shared_from_this<UpstreamPool> {
-    boost::asio::executor ex;
+    boost::asio::any_io_executor ex;
 
     std::deque<UpstreamServerRef> _pool;
     size_t lastUseUpstreamIndex = 0;
@@ -99,7 +99,7 @@ class UpstreamPool : public std::enable_shared_from_this<UpstreamPool> {
     std::shared_ptr<ConnectTestHttps> connectTestHttps;
 
 public:
-    UpstreamPool(boost::asio::executor ex,
+    UpstreamPool(boost::asio::any_io_executor ex,
                  std::shared_ptr<TcpTest> tcpTest,
                  std::shared_ptr<ConnectTestHttps> connectTestHttps);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,7 @@
  */
 
 #include <iostream>
-#include <boost/asio/executor.hpp>
+#include <boost/asio/any_io_executor.hpp>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/strand.hpp>
 #include <boost/asio/signal_set.hpp>
@@ -92,7 +92,7 @@ int main(int argc, const char *argv[]) {
 
     try {
         boost::asio::io_context ioc;
-        boost::asio::executor ex = boost::asio::make_strand(ioc);
+        boost::asio::any_io_executor ex = boost::asio::make_strand(ioc);
 
         auto configLoader = std::make_shared<ConfigLoader>();
         configLoader->load(config_file);


### PR DESCRIPTION
First of all thank you for your great work, I have found your program very useful!

This PR addressing 2 issues:

1. Thanks to  [icaca](https://github.com/icaca) at [Issue #1](https://github.com/Socks5Balancer/Socks5BalancerAsio/issues/1) for inspiring to create Docker version.

2. Thanks to [Ykidia](https://github.com/Ykidia) for solution to get Boost v1.74+ support at [Issue #2](https://github.com/Socks5Balancer/Socks5BalancerAsio/issues/2).

> But Boost v1.74+ support is **NOT backwards compatible** with Boost v1.71-1.73 you recommend in README.
> So that needs to be stated clearly like "either checkout v1.0 for Boost <=1.73 or later for latest Boost"
> I have compiled latest docker image for Boost 1.77.

I have replaced with ```any_io_executor```, fixed type conversion and it works now.

Also added mention to my repo with [Docker version](https://github.com/fossforreal/Socks5BalancerAsio-Docker), if you dont mind.

Good luck!

P.S. Better to add compilation instructions for Boost before v1.74, they can be found mainly [here](https://github.com/fossforreal/Socks5BalancerAsio-Docker/blob/d76346b2631cdc39221d40013fb9ab76e6d4ced1/alpine-build.sh) and [here](https://github.com/fossforreal/Socks5BalancerAsio-Docker/blob/d76346b2631cdc39221d40013fb9ab76e6d4ced1/alpine-build/build.sh).